### PR TITLE
Remove Database and Filesystem IO

### DIFF
--- a/plugins/hmail-aliases/LICENSE
+++ b/plugins/hmail-aliases/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Karobolas
+Copyright (c) 2019 Karobolas, 2023 Oxymoron290
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/plugins/hmail-aliases/index.php
+++ b/plugins/hmail-aliases/index.php
@@ -9,11 +9,12 @@ class HmailAliasesPlugin extends \RainLoop\Plugins\AbstractPlugin
 
     public function Supported()
     {
-        if (!class_exists('mysqli')) {
-            return 'The PHP exention mysqli must be installed to use this plugin';
-        }
+		if (!class_exists('COM'))
+		{
+			return 'The PHP extension COM must be installed to use this plugin';
+		}
 
-        return '';
+		return '';
     }
 
     /**
@@ -22,19 +23,104 @@ class HmailAliasesPlugin extends \RainLoop\Plugins\AbstractPlugin
     */
     public function loginPostLoginProvide(\RainLoop\Model\Account &$oAccount)
     {
-        $dbservername = \trim($this->Config()->Get('plugin', 'hamilserver', ''));
-        $dbusername = \trim($this->Config()->Get('plugin', 'hmaildbusername', ''));
-        $dbpassword = \trim($this->Config()->Get('plugin', 'hmaildbpassword', ''));
-        $dbname = \trim($this->Config()->Get('plugin', 'hmaildbtable', ''));
-        $dbport = \trim($this->Config()->Get('plugin', 'hmaildbport', ''));
-        $datadir = \trim($this->Config()->Get('plugin', 'rainloopDatalocation', ''));
+		$oProvider = new HmailserverChangePasswordDriver();
+		$oLogger($this->Manager()->Actions()->Logger());
+		$sLogin = (string) $this->Config()->Get('plugin', 'login', '');
+		$sPassword = (string) $this->Config()->Get('plugin', 'password', '');
+		$bResult = false;
 
-        if ($datadir != ""){
-          $userpath = $datadir.'data/_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
-        } else {
-          $userpath = APP_INDEX_ROOT_PATH.'_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
-        }
+		try
+		{
+			$oHmailApp = new COM("hMailServer.Application");
+			$oHmailApp->Connect();
 
+			if ($oHmailApp->Authenticate($sLogin, $sPassword))
+			{
+				$sEmail = $oHmailAccount->Email();
+				$sDomain = \MailSo\Base\Utils::GetDomainFromEmail($sEmail);
+
+				$oHmailDomain = $oHmailApp->Domains->ItemByName($sDomain);
+				if ($oHmailDomain)
+				{
+					$oHmailAccount = $oHmailDomain->Accounts->ItemByAddress($sEmail);
+					if ($oHmailAccount)
+					{
+                        // Get account details for alias
+                        
+                        $firstName = $oHmailAccount->PersonFirstName;
+                        $lastName = $oHmailAccount->PersonLastName;
+                        if ($firstName == "" && $lastName == "") {
+                            $name = "";
+                        } else {
+                            $name = $firstName." ".$lastName;
+                        }
+                        
+                        // ========vvv========= Update Rainloop Idnetity ========vvv=========
+
+                        $datadir = \trim($this->Config()->Get('plugin', 'rainloopDatalocation', ''));
+                        if ($datadir != ""){
+                            $userpath = $datadir.'data/_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
+                        } else {
+                            $userpath = APP_INDEX_ROOT_PATH.'_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
+                        }
+        
+                        $newidentitiesobj = array();
+                        
+                        //Get existing settings. If not a alias created by hmail. Transfer settings to the new array.
+                        $identities = file_get_contents($userpath, true);
+                        if ($identities != "") {
+                            $identities = json_decode($identities, true);
+                            error_log(print_r($identities, true));
+                            foreach ($identities as $row) {
+                                if (strpos($row['Id'], 'HMAIL') === false) {
+                                    array_push($newidentitiesobj, $row);
+                                }
+                            }
+                        }
+                        
+                        $obj = array();
+                        $obj['Id'] = "HMAIL".base64_encode($sEmail);
+                        $obj['Email'] = $sEmail;
+                        $obj['Name'] = $name;
+                        $obj['ReplyTo'] = "";
+                        $obj['Bcc'] = "";
+                        $obj['Signature'] = "";
+                        $obj['SignatureInsertBefore'] = false;
+                        array_push($newidentitiesobj, $obj);
+                        
+                        file_put_contents($userpath, json_encode($newidentitiesobj));
+                        // ========^^^========= Update Rainloop Idnetity ========^^^=========
+
+						$bResult = true;
+					}
+					else
+					{
+						$this->oLogger->Write('HMAILSERVER: Unknown account ('.$sEmail.')', \MailSo\Log\Enumerations\Type::ERROR);
+					}
+				}
+				else
+				{
+					$this->oLogger->Write('HMAILSERVER: Unknown domain ('.$sDomain.')', \MailSo\Log\Enumerations\Type::ERROR);
+				}
+			}
+			else
+			{
+				$this->oLogger->Write('HMAILSERVER: Auth error', \MailSo\Log\Enumerations\Type::ERROR);
+			}
+		}
+		catch (\Exception $oException)
+		{
+			if ($this->oLogger)
+			{
+				$this->oLogger->WriteException($oException);
+			}
+		}
+
+		return $bResult;
+        
+        //==========================================================================
+
+        
         $hmailconn = mysqli_connect($dbservername, $dbusername, $dbpassword, $dbname, $dbport);
 
         // Check connection
@@ -94,17 +180,11 @@ class HmailAliasesPlugin extends \RainLoop\Plugins\AbstractPlugin
     public function configMapping()
     {
         return array(
-          \RainLoop\Plugins\Property::NewInstance('hamilserver')->SetLabel('db-host')
-            ->SetDefaultValue('localhost'),
-          \RainLoop\Plugins\Property::NewInstance('hmaildbusername')->SetLabel('db-username')
-            ->SetDefaultValue(''),
-          \RainLoop\Plugins\Property::NewInstance('hmaildbpassword')->SetLabel('db-password')
-            ->SetType(\RainLoop\Enumerations\PluginPropertyType::PASSWORD),
-          \RainLoop\Plugins\Property::NewInstance('hmaildbtable')->SetLabel('db-table')
-            ->SetDefaultValue('mailserver'),
-          \RainLoop\Plugins\Property::NewInstance('hmaildbport')->SetLabel('db-port')
-            ->SetDefaultValue('3306')
-            ->SetDescription('Connect to mysql hmailserver. The user must have rights to read "hm_aliases" table.'),
+		  \RainLoop\Plugins\Property::NewInstance('login')->SetLabel('HmailServer Admin Login')
+			->SetDefaultValue('Administrator'),
+		  \RainLoop\Plugins\Property::NewInstance('password')->SetLabel('HmailServer Admin Password')
+			->SetType(\RainLoop\Enumerations\PluginPropertyType::PASSWORD)
+			->SetDefaultValue(''),
           \RainLoop\Plugins\Property::NewInstance('rainloopDatalocation')->SetLabel('Data folder location')
             ->SetDefaultValue('')
             ->SetDescription('Incase of custom data directory location. Eg. nextcloud/owncloud version (Leave blank for default)')

--- a/plugins/hmail-aliases/index.php
+++ b/plugins/hmail-aliases/index.php
@@ -23,155 +23,100 @@ class HmailAliasesPlugin extends \RainLoop\Plugins\AbstractPlugin
     */
     public function loginPostLoginProvide(\RainLoop\Model\Account &$oAccount)
     {
-		$oProvider = new HmailserverChangePasswordDriver();
-		$oLogger($this->Manager()->Actions()->Logger());
-		$sLogin = (string) $this->Config()->Get('plugin', 'login', '');
-		$sPassword = (string) $this->Config()->Get('plugin', 'password', '');
-		$bResult = false;
+	$oProvider = new HmailserverChangePasswordDriver();
+	$oLogger($this->Manager()->Actions()->Logger());
+	$sLogin = (string) $this->Config()->Get('plugin', 'login', '');
+	$sPassword = (string) $this->Config()->Get('plugin', 'password', '');
+	$bResult = false;
 
-		try
+	try
+	{
+		$oHmailApp = new COM("hMailServer.Application");
+		$oHmailApp->Connect();
+
+		if ($oHmailApp->Authenticate($sLogin, $sPassword))
 		{
-			$oHmailApp = new COM("hMailServer.Application");
-			$oHmailApp->Connect();
+			$sEmail = $oHmailAccount->Email();
+			$sDomain = \MailSo\Base\Utils::GetDomainFromEmail($sEmail);
 
-			if ($oHmailApp->Authenticate($sLogin, $sPassword))
+			$oHmailDomain = $oHmailApp->Domains->ItemByName($sDomain);
+			if ($oHmailDomain)
 			{
-				$sEmail = $oHmailAccount->Email();
-				$sDomain = \MailSo\Base\Utils::GetDomainFromEmail($sEmail);
-
-				$oHmailDomain = $oHmailApp->Domains->ItemByName($sDomain);
-				if ($oHmailDomain)
+				$oHmailAccount = $oHmailDomain->Accounts->ItemByAddress($sEmail);
+				if ($oHmailAccount)
 				{
-					$oHmailAccount = $oHmailDomain->Accounts->ItemByAddress($sEmail);
-					if ($oHmailAccount)
-					{
-                        // Get account details for alias
-                        
-                        $firstName = $oHmailAccount->PersonFirstName;
-                        $lastName = $oHmailAccount->PersonLastName;
-                        if ($firstName == "" && $lastName == "") {
-                            $name = "";
-                        } else {
-                            $name = $firstName." ".$lastName;
-                        }
-                        
-                        // ========vvv========= Update Rainloop Idnetity ========vvv=========
+		// Get account details for alias
 
-                        $datadir = \trim($this->Config()->Get('plugin', 'rainloopDatalocation', ''));
-                        if ($datadir != ""){
-                            $userpath = $datadir.'data/_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
-                        } else {
-                            $userpath = APP_INDEX_ROOT_PATH.'_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
-                        }
-        
-                        $newidentitiesobj = array();
-                        
-                        //Get existing settings. If not a alias created by hmail. Transfer settings to the new array.
-                        $identities = file_get_contents($userpath, true);
-                        if ($identities != "") {
-                            $identities = json_decode($identities, true);
-                            error_log(print_r($identities, true));
-                            foreach ($identities as $row) {
-                                if (strpos($row['Id'], 'HMAIL') === false) {
-                                    array_push($newidentitiesobj, $row);
-                                }
-                            }
-                        }
-                        
-                        $obj = array();
-                        $obj['Id'] = "HMAIL".base64_encode($sEmail);
-                        $obj['Email'] = $sEmail;
-                        $obj['Name'] = $name;
-                        $obj['ReplyTo'] = "";
-                        $obj['Bcc'] = "";
-                        $obj['Signature'] = "";
-                        $obj['SignatureInsertBefore'] = false;
-                        array_push($newidentitiesobj, $obj);
-                        
-                        file_put_contents($userpath, json_encode($newidentitiesobj));
-                        // ========^^^========= Update Rainloop Idnetity ========^^^=========
+		$firstName = $oHmailAccount->PersonFirstName;
+		$lastName = $oHmailAccount->PersonLastName;
+		if ($firstName == "" && $lastName == "") {
+		    $name = "";
+		} else {
+		    $name = $firstName." ".$lastName;
+		}
 
-						$bResult = true;
-					}
-					else
-					{
-						$this->oLogger->Write('HMAILSERVER: Unknown account ('.$sEmail.')', \MailSo\Log\Enumerations\Type::ERROR);
-					}
+		// ========vvv========= Update Rainloop Idnetity ========vvv=========
+
+		$datadir = \trim($this->Config()->Get('plugin', 'rainloopDatalocation', ''));
+		if ($datadir != ""){
+		    $userpath = $datadir.'data/_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
+		} else {
+		    $userpath = APP_INDEX_ROOT_PATH.'_data_/_default_/storage/cfg/'.substr($oAccount->Email(), 0, 2).'/'.$oAccount->Email().'/identities';
+		}
+
+		$newidentitiesobj = array();
+
+		//Get existing settings. If not a alias created by hmail. Transfer settings to the new array.
+		$identities = file_get_contents($userpath, true);
+		if ($identities != "") {
+		    $identities = json_decode($identities, true);
+		    error_log(print_r($identities, true));
+		    foreach ($identities as $row) {
+			if (strpos($row['Id'], 'HMAIL') === false) {
+			    array_push($newidentitiesobj, $row);
+			}
+		    }
+		}
+
+		$obj = array();
+		$obj['Id'] = "HMAIL".base64_encode($sEmail);
+		$obj['Email'] = $sEmail;
+		$obj['Name'] = $name;
+		$obj['ReplyTo'] = "";
+		$obj['Bcc'] = "";
+		$obj['Signature'] = "";
+		$obj['SignatureInsertBefore'] = false;
+		array_push($newidentitiesobj, $obj);
+
+		file_put_contents($userpath, json_encode($newidentitiesobj));
+		// ========^^^========= Update Rainloop Idnetity ========^^^=========
+
+					$bResult = true;
 				}
 				else
 				{
-					$this->oLogger->Write('HMAILSERVER: Unknown domain ('.$sDomain.')', \MailSo\Log\Enumerations\Type::ERROR);
+					$this->oLogger->Write('HMAILSERVER: Unknown account ('.$sEmail.')', \MailSo\Log\Enumerations\Type::ERROR);
 				}
 			}
 			else
 			{
-				$this->oLogger->Write('HMAILSERVER: Auth error', \MailSo\Log\Enumerations\Type::ERROR);
+				$this->oLogger->Write('HMAILSERVER: Unknown domain ('.$sDomain.')', \MailSo\Log\Enumerations\Type::ERROR);
 			}
 		}
-		catch (\Exception $oException)
+		else
 		{
-			if ($this->oLogger)
-			{
-				$this->oLogger->WriteException($oException);
-			}
+			$this->oLogger->Write('HMAILSERVER: Auth error', \MailSo\Log\Enumerations\Type::ERROR);
 		}
+	}
+	catch (\Exception $oException)
+	{
+		if ($this->oLogger)
+		{
+			$this->oLogger->WriteException($oException);
+		}
+	}
 
-		return $bResult;
-        
-        //==========================================================================
-
-        
-        $hmailconn = mysqli_connect($dbservername, $dbusername, $dbpassword, $dbname, $dbport);
-
-        // Check connection
-        if (!$hmailconn) {
-            echo "Hmail-aliases: connection to db failed";
-            return;
-        }
-        //Get aliases
-        $result = $hmailconn->query("SELECT * FROM " . $dbname . ".hm_aliases WHERE aliasvalue='".$oAccount->Email()."'");
-
-        if ($result->num_rows > 0) {
-            $newidentitiesobj = array();
-
-            //Get user account
-            $result2 = $hmailconn->query("SELECT * FROM " . $dbname . ".hm_accounts WHERE accountaddress='".$oAccount->Email()."'");
-            $result2 = $result2->fetch_assoc();
-            $firstname = $result2['accountpersonfirstname'];
-            $lastname = $result2['accountpersonlastname'];
-
-            if ($firstname == "" && $lastname == "") {
-                $name = "";
-            } else {
-                $name = $firstname." ".$lastname;
-            }
-
-            //Get existing settings. If not a alias created by hmail. Transfer settings to the new array.
-            $identities = file_get_contents($userpath, true);
-            if ($identities != "") {
-                $identities = json_decode($identities, true);
-                error_log(print_r($identities, true));
-                foreach ($identities as $row) {
-                    if (strpos($row['Id'], 'HMAIL') === false) {
-                        array_push($newidentitiesobj, $row);
-                    }
-                }
-            }
-
-            // output data of each row
-            while ($row = $result->fetch_assoc()) {
-                $obj = array();
-                $obj['Id'] = "HMAIL".base64_encode($row["aliasname"]);
-                $obj['Email'] = $row["aliasname"];
-                $obj['Name'] = $name;
-                $obj['ReplyTo'] = "";
-                $obj['Bcc'] = "";
-                $obj['Signature'] = "";
-                $obj['SignatureInsertBefore'] = false;
-                array_push($newidentitiesobj, $obj);
-            }
-            file_put_contents($userpath, json_encode($newidentitiesobj));
-        }
+	return $bResult;
     }
 
     /**

--- a/plugins/hmail-aliases/index.php
+++ b/plugins/hmail-aliases/index.php
@@ -62,10 +62,17 @@ class HmailAliasesPlugin extends \RainLoop\Plugins\AbstractPlugin
                         }
                         
                         // ========vvv========= Update Rainloop Identity ========vvv=========
-                        $identity = \RainLoop\Model\Identity::NewInstanceFromAccount($oAccount);
+                        $identities = $this->Manager()->Actions()->GetIdentities($oAccount);
+                        if(empty($identities)){
+                            // I am assuming [0] is the "default" identity...
+                            $identity = \RainLoop\Model\Identity::NewInstanceFromAccount($oAccount);
+                            array_push($identities, $identity);
+                        }
+                        
+                        $identity = $identities[0];
                         $identity->FromJSON(array('Email' => $sEmail, 'Name' => $name));
                         // TODO Account::DoIdentityUpdate is possible if I knew how to use actoinParams
-                        $result = $this->Manager()->Actions()->SetIdentities($oAccount, array($identity));
+                        $result = $this->Manager()->Actions()->SetIdentities($oAccount, $identities);
                         $oLogger->Write('HMAILSERVER Identity Update Successful');
                         // ========^^^========= Update Rainloop Idnetity ========^^^=========
 						$bResult = true;


### PR DESCRIPTION
Instead of connecting directly to mysql, I've changed it to use the hMailServer COM api instead. Also, instead of reading/writing directly to the user's identities file, I changed it to interface with it using the existing functions as part of the RainLoop base package.